### PR TITLE
リプライ投稿機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -34,7 +34,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:content, :image).merge(user_id: current_user.id)
+    params.require(:post).permit(:content, :image, :reply_to).merge(user_id: current_user.id, replied_count: 0)
   end
 
   def profile_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,7 +8,7 @@ class PostsController < ApplicationController
   end
 
   def create
-    @post = Post.create(post_params)
+    @post = Post.post_create(post_params)
   end
   
   def update

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,7 +8,8 @@ class PostsController < ApplicationController
   end
 
   def create
-    @post = Post.post_create(post_params)
+    @post = Post.create(post_params)
+    Post.reply_count(post_params[:reply_to])
   end
   
   def update
@@ -19,6 +20,7 @@ class PostsController < ApplicationController
   end
 
   def destroy
+    Post.destroy_reply(params[:id])
     Post.destroy(params[:id])
   end
 

--- a/app/javascript/posts/form.vue
+++ b/app/javascript/posts/form.vue
@@ -15,6 +15,7 @@
             autofocus
             required></textarea>
           <input type="file" name="post[image]" @change="selectImage" id="post-image">
+          <input type="hidden" v-model="uploadReplyTo" name="post[reply_to]">
           <button type="submit" :class="['button', 'is-primary', isEmpty]" v-show="!isEdit">投稿する</button>
           <button type="submit" :class="['button', 'is-primary', isEmpty]" v-show="isEdit">編集する</button>
         </form>
@@ -28,17 +29,19 @@
 <script>
 export default {
   props: {
-    formActive: {
-      type: Boolean,
-    },
-    editInfo: {
-      type: Object,
-    }
+    formActive: Boolean,
+    editInfo: Object,
+    replyInfo: Object
   },
+  emits: [
+    'do-post',
+    'close-form',
+  ],
   data() {
     return {
       uploadContent: '',
       uploadImage: null,
+      uploadReplyTo: null,
     }
   },
   computed: {
@@ -65,6 +68,14 @@ export default {
       },
       deep: true,
     },
+    replyInfo: {
+      handler: function(next) {
+        if (next.reply_to) {
+          this.uploadReplyTo = next.reply_to
+        }
+      },
+      deep: true,
+    }
   },
   methods: {
     selectImage: function(e) {
@@ -76,6 +87,9 @@ export default {
       formData.append('post[content]', this.uploadContent)
       if (this.uploadImage) {
         formData.append('post[image]', this.uploadImage)
+      }
+      if (this.uploadReplyTo) {
+        formData.append('post[reply_to]', this.uploadReplyTo)
       }
       this.$emit("do-post", formData)
       this.uploadContent = ''

--- a/app/javascript/posts/index.vue
+++ b/app/javascript/posts/index.vue
@@ -144,10 +144,10 @@ export default {
         })
         .catch(error => console.log(error))
     },
-    deletePost: function(post, index) {
+    deletePost: function(post_id, index) {
       window.alert("Are you sure to DELETE?")
 
-      fetch(`/posts/${post.id}`, {
+      fetch(`/posts/${post_id}`, {
           method: 'DELETE',
           headers: {
             'X-CSRF-Token': csrfToken(),

--- a/app/javascript/posts/index.vue
+++ b/app/javascript/posts/index.vue
@@ -3,6 +3,7 @@
   <post-form
     :form-active="isActives.formActive"
     :edit-info="editInfo"
+    :reply-info="replyInfo"
     @close-form="closeForm"
     @do-post="doPost($event)"
   ></post-form>
@@ -43,6 +44,7 @@
           @edit-post="editPost($event, index)"
           @open-img-modal="openImgModal($event)"
           @set-user-posts="setUserPosts($event)"
+          @do-reply="doReply($event)"
         ></post>
       </div>
     </div>
@@ -92,6 +94,10 @@ export default {
         name: '',
         showProfile: {},
       },
+
+      replyInfo: {
+        reply_to: undefined,
+      }
     }
   },
   watch: {
@@ -174,6 +180,10 @@ export default {
       this.showUser.name = user.name
       this.showUser.showProfile.nickname = user.profile.nickname
       this.fetchProfile(user.id)
+    },
+    doReply: function(post_id) {
+      this.replyInfo.reply_to = post_id
+      this.openForm()
     },
     fetchProfile: function(userId) {
       fetch(`/posts/user/${userId}`)

--- a/app/javascript/posts/post.vue
+++ b/app/javascript/posts/post.vue
@@ -44,10 +44,17 @@
   </div>
 
   <div class="columns">
-    <div class="content is-medium column is-two-third">
-      <p>{{ post.content }}</p>
-      <!-- <a>@bulmaio</a>.
-      <a href="#">#css</a> <a href="#">#responsive</a> -->
+    <div class="content is-left-content is-medium column is-two-third">
+      <div class="text-area">
+        <p>{{ post.content }}</p>
+        <!-- <a>@bulmaio</a>.
+        <a href="#">#css</a> <a href="#">#responsive</a> -->
+      </div>
+      <div class="rel-bar columns">
+        <div class="column">た</div>
+        <div class="column">ま</div>
+        <div class="column">ぷ</div>
+      </div>
     </div>
     <div class="block column is-one-third" v-if="post.image">
         <img @click="openImageModal(post.image)" :src="post.image" alt="Placeholder image">
@@ -102,5 +109,18 @@ export default {
 }
 .right-margin {
   margin-right: 10px;
+}
+.is-left-content {
+  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.is-left-content> .text-area {
+  margin-bottom: 10px;
+}
+.rel-bar> .column {
+  padding-bottom: 0;
+  width: 80px;
 }
 </style>

--- a/app/javascript/posts/post.vue
+++ b/app/javascript/posts/post.vue
@@ -55,7 +55,7 @@
   </div>
 </div>
 <div class="card-footer">
-  <div class="card-footer-item">
+  <div class="card-footer-item pointer" @click="doReply(post.id)">
     <span>た</span>
     <span v-if="post.replied_count !== 0">{{ post.replied_count }}</span>
   </div>
@@ -75,7 +75,8 @@ export default {
     'delete-post',
     'edit-post',
     'open-img-modal',
-    'set-user-posts'
+    'set-user-posts',
+    'do-reply'
   ],
   computed: {
     isCurrentUser: function() {
@@ -94,6 +95,9 @@ export default {
     },
     doSetUserPosts: function(user) {
       this.$emit("set-user-posts", user)
+    },
+    doReply: function(post_id) {
+      this.$emit("do-reply", post_id)
     }
   }
 }
@@ -104,7 +108,8 @@ export default {
   white-space: pre-wrap;
   word-wrap: break-word;
 }
-.media-content> .title {
+.media-content> .title,
+.card-footer-item {
   cursor: pointer;
 }
 .dropdown button {

--- a/app/javascript/posts/post.vue
+++ b/app/javascript/posts/post.vue
@@ -45,21 +45,22 @@
 
   <div class="columns">
     <div class="content is-left-content is-medium column is-two-third">
-      <div class="text-area">
-        <p>{{ post.content }}</p>
-        <!-- <a>@bulmaio</a>.
-        <a href="#">#css</a> <a href="#">#responsive</a> -->
-      </div>
-      <div class="rel-bar columns">
-        <div class="column">た</div>
-        <div class="column">ま</div>
-        <div class="column">ぷ</div>
-      </div>
+      <p>{{ post.content }}</p>
+      <!-- <a>@bulmaio</a>.
+      <a href="#">#css</a> <a href="#">#responsive</a> -->
     </div>
     <div class="block column is-one-third" v-if="post.image">
         <img @click="openImageModal(post.image)" :src="post.image" alt="Placeholder image">
     </div>
   </div>
+</div>
+<div class="card-footer">
+  <div class="card-footer-item">
+    <span>た</span>
+    <span v-if="post.replied_count !== 0">{{ post.replied_count }}</span>
+  </div>
+  <div class="card-footer-item">ま</div>
+  <div class="card-footer-item">ぷ</div>
 </div>
 </template>
 
@@ -109,18 +110,5 @@ export default {
 }
 .right-margin {
   margin-right: 10px;
-}
-.is-left-content {
-  margin-bottom: 0;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-}
-.is-left-content> .text-area {
-  margin-bottom: 10px;
-}
-.rel-bar> .column {
-  padding-bottom: 0;
-  width: 80px;
 }
 </style>

--- a/app/javascript/posts/post.vue
+++ b/app/javascript/posts/post.vue
@@ -34,7 +34,7 @@
               Edit
             </a>
             <hr class="dropdown-divider">
-            <a @click="doDeletePost(post)" class="dropdown-item">
+            <a @click="doDeletePost(post.id)" class="dropdown-item">
               Delete
             </a>
           </div>
@@ -71,14 +71,20 @@ export default {
     current_user_name: String,
     menu_bar: String,
   },
+  emits: [
+    'delete-post',
+    'edit-post',
+    'open-img-modal',
+    'set-user-posts'
+  ],
   computed: {
     isCurrentUser: function() {
       return this.post.user.name === this.current_user_name
     },
   },
   methods: {
-    doDeletePost: function(post) {
-      this.$emit("delete-post", post)
+    doDeletePost: function(post_id) {
+      this.$emit("delete-post", post_id)
     },
     doEditPost: function(post) {
       this.$emit("edit-post", post)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,12 +4,18 @@ class Post < ApplicationRecord
 
   validates :content, presence: true, length: { maximum: 140 }
 
-  def self.post_create(params)
-    post = Post.create(params)
-    if params[:reply_to]
-      to_post = Post.find(params[:reply_to])
+  def self.reply_count(to_id)
+    if to_id
+      to_post = Post.find(to_id)
       to_post.update(replied_count: to_post[:replied_count] += 1)
     end
-    return post
+  end
+  
+  def self.destroy_reply(post_id)
+    post = Post.find(post_id)
+    if post[:reply_to]
+      to_post = Post.find(post[:reply_to])
+      to_post.update(replied_count: to_post[:replied_count] -= 1)
+    end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,4 +3,13 @@ class Post < ApplicationRecord
   has_one_attached :image
 
   validates :content, presence: true, length: { maximum: 140 }
+
+  def self.post_create(params)
+    post = Post.create(params)
+    if params[:reply_to]
+      to_post = Post.find(params[:reply_to])
+      to_post.update(replied_count: to_post[:replied_count] += 1)
+    end
+    return post
+  end
 end

--- a/app/views/posts/create.json.jbuilder
+++ b/app/views/posts/create.json.jbuilder
@@ -1,5 +1,7 @@
 json.id @post.id
 json.content @post.content
+json.reply_to @post.reply_to
+json.replied_count @post.replied_count
 json.created_at @post.created_at
 if @post.image.attached?
   json.image url_for(@post.image)

--- a/app/views/posts/index.json.jbuilder
+++ b/app/views/posts/index.json.jbuilder
@@ -2,6 +2,8 @@ json.set! :posts do
   json.array! @posts do |post|
     json.id post.id
     json.content post.content
+    json.reply_to post.reply_to
+    json.replied_count post.replied_count
     json.created_at post.created_at
     if post.image.attached?
       json.image url_for(post.image)

--- a/db/migrate/20210127094724_add_postid_to_posts.rb
+++ b/db/migrate/20210127094724_add_postid_to_posts.rb
@@ -1,5 +1,6 @@
 class AddPostidToPosts < ActiveRecord::Migration[6.0]
   def change
-    add_column :posts, :post_id, :integer
+    add_column :posts, :reply_to, :integer
+    add_column :posts, :replied_count, :integer
   end
 end

--- a/db/migrate/20210127094724_add_postid_to_posts.rb
+++ b/db/migrate/20210127094724_add_postid_to_posts.rb
@@ -1,0 +1,5 @@
+class AddPostidToPosts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :posts, :post_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_26_064708) do
+ActiveRecord::Schema.define(version: 2021_01_27_094724) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2021_01_26_064708) do
     t.text "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "post_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,7 +49,8 @@ ActiveRecord::Schema.define(version: 2021_01_27_094724) do
     t.text "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "post_id"
+    t.integer "reply_to"
+    t.integer "replied_count"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/er.drawio
+++ b/er.drawio
@@ -1,6 +1,6 @@
-<mxfile host="65bd71144e" modified="2021-01-25T18:47:55.895Z" agent="5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36" etag="kgre8q9FFJzx6SbzbtoR" version="13.10.0" type="embed">
+<mxfile host="65bd71144e" modified="2021-01-27T09:40:42.829Z" agent="5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.52.1 Chrome/83.0.4103.122 Electron/9.3.5 Safari/537.36" etag="ny_079tUfsmR7IfydkQt" version="13.10.0" type="embed">
     <diagram id="Br-Pnz5gZ4UJlSzY0Lrw" name="Page-1">
-        <mxGraphModel dx="788" dy="612" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+        <mxGraphModel dx="882" dy="612" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -37,13 +37,16 @@
                     <mxGeometry y="156" width="140" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="7" value="posts" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;fillColor=#f0a30a;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;strokeColor=#BD7000;fontColor=#ffffff;" parent="1" vertex="1">
-                    <mxGeometry x="420" y="520" width="140" height="78" as="geometry"/>
+                    <mxGeometry x="420" y="520" width="140" height="104" as="geometry"/>
                 </mxCell>
                 <mxCell id="8" value="user_id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="7" vertex="1">
                     <mxGeometry y="26" width="140" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="9" value="content" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="7" vertex="1">
+                <mxCell id="120" value="post_id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" vertex="1" parent="7">
                     <mxGeometry y="52" width="140" height="26" as="geometry"/>
+                </mxCell>
+                <mxCell id="9" value="content" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="7" vertex="1">
+                    <mxGeometry y="78" width="140" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="11" value="terms" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;fillColor=#a20025;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;strokeColor=#6F0000;fontColor=#ffffff;" parent="1" vertex="1">
                     <mxGeometry x="610" y="320" width="140" height="156" as="geometry">
@@ -53,7 +56,7 @@
                 <mxCell id="12" value="sentence_id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="11" vertex="1">
                     <mxGeometry y="26" width="140" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="119" value="word_id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" vertex="1" parent="11">
+                <mxCell id="119" value="word_id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="11" vertex="1">
                     <mxGeometry y="52" width="140" height="26" as="geometry"/>
                 </mxCell>
                 <mxCell id="14" value="lesson" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="11" vertex="1">
@@ -159,33 +162,6 @@
                 <mxCell id="107" value="score" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="66" vertex="1">
                     <mxGeometry y="104" width="140" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="78" value="comments" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;fillColor=#f0a30a;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;strokeColor=#BD7000;fontColor=#ffffff;" parent="1" vertex="1">
-                    <mxGeometry x="420" y="650" width="140" height="104" as="geometry"/>
-                </mxCell>
-                <mxCell id="79" value="user_id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="78" vertex="1">
-                    <mxGeometry y="26" width="140" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="80" value="post_id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="78" vertex="1">
-                    <mxGeometry y="52" width="140" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="81" value="content" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="78" vertex="1">
-                    <mxGeometry y="78" width="140" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="82" value="" style="endArrow=ERone;html=1;startArrow=ERoneToMany;startFill=0;endFill=0;" parent="1" source="78" target="9" edge="1">
-                    <mxGeometry width="50" height="50" relative="1" as="geometry">
-                        <mxPoint x="290" y="300" as="sourcePoint"/>
-                        <mxPoint x="487" y="620" as="targetPoint"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="83" value="" style="edgeStyle=elbowEdgeStyle;elbow=horizontal;endArrow=ERoneToMany;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;startArrow=ERone;startFill=0;endFill=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="6" target="79" edge="1">
-                    <mxGeometry width="50" height="50" relative="1" as="geometry">
-                        <mxPoint x="370" y="450" as="sourcePoint"/>
-                        <mxPoint x="430" y="579" as="targetPoint"/>
-                        <Array as="points">
-                            <mxPoint x="380" y="600"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
                 <mxCell id="84" value="" style="edgeStyle=elbowEdgeStyle;elbow=horizontal;endArrow=ERone;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;startArrow=ERone;startFill=0;endFill=0;" parent="1" source="117" target="4" edge="1">
                     <mxGeometry width="50" height="50" relative="1" as="geometry">
                         <mxPoint x="140" y="380" as="sourcePoint"/>
@@ -201,10 +177,13 @@
                 <mxCell id="87" value="post_id" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="85" vertex="1">
                     <mxGeometry y="52" width="140" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="94" value="" style="edgeStyle=elbowEdgeStyle;elbow=vertical;endArrow=ERone;html=1;entryX=0.314;entryY=1.038;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.75;exitY=0;exitDx=0;exitDy=0;endFill=0;startArrow=ERoneToMany;startFill=0;" parent="1" source="85" target="9" edge="1">
+                <mxCell id="94" value="" style="edgeStyle=elbowEdgeStyle;elbow=vertical;endArrow=ERone;html=1;endFill=0;startArrow=ERoneToMany;startFill=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0.493;entryY=1.038;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="86" target="9" edge="1">
                     <mxGeometry width="50" height="50" relative="1" as="geometry">
-                        <mxPoint x="370" y="490" as="sourcePoint"/>
+                        <mxPoint x="410" y="689" as="sourcePoint"/>
                         <mxPoint x="420" y="440" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="460" y="689"/>
+                        </Array>
                     </mxGeometry>
                 </mxCell>
                 <mxCell id="96" value="" style="endArrow=ERone;html=1;startArrow=ERoneToMany;startFill=0;endFill=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;" parent="1" source="85" edge="1">


### PR DESCRIPTION
#What
* postsテーブルにreply_to, replied_countカラム追加
* リプライボタンを押すとreply_toカラムに相手postのidが入った形で投稿
* リプライ投稿時は保存後に相手postのreplied_countを+1するメソッド実装
* リプライ投稿削除時は削除前に相手postのreplied_countを-1するメソッド実装

# Why
投稿の結びつきを生むことでリッチなSNSを作り出すため